### PR TITLE
[sc-106335] Trap all cache write errors

### DIFF
--- a/VERSION.yml
+++ b/VERSION.yml
@@ -2,4 +2,4 @@
 :major: 0
 :minor: 8 
 :patch: 2
-:build: 0
+:build: 2

--- a/VERSION.yml
+++ b/VERSION.yml
@@ -1,5 +1,5 @@
 ---
 :major: 0
 :minor: 8 
-:patch: 1
-:build: 1 
+:patch: 2
+:build: 0

--- a/lib/method_cache.rb
+++ b/lib/method_cache.rb
@@ -10,7 +10,7 @@ module MethodCache
     proxy = opts.kind_of?(Proxy) ? opts : Proxy.new(method_name, opts)
 
     if self.class == Class
-      return if instance_methods.include?(proxy.method_name_without_caching)
+      return if instance_methods.include?(proxy.method_name_without_caching.intern)
 
       if cached_instance_methods.empty?
         include(InvalidationMethods)
@@ -45,7 +45,7 @@ module MethodCache
     method_name = method_name.to_sym
     proxy = opts.kind_of?(Proxy) ? opts : Proxy.new(method_name, opts)
 
-    return if methods.include?(proxy.method_name_without_caching)
+    return if methods.include?(proxy.method_name_without_caching.intern)
 
     if cached_class_methods.empty?
       extend(InvalidationMethods)

--- a/lib/method_cache/proxy.rb
+++ b/lib/method_cache/proxy.rb
@@ -190,7 +190,7 @@ module MethodCache
         else
           cache.set(key, value, expiry(value))
         end
-      rescue Dalli::DalliError => e
+      rescue Error => e
         if e.message =~ /Value too large/
           puts "WARNING #{self.class}: #{key} not written when trying to #write_to_cache. #{e.message}"
           nil

--- a/method_cache.gemspec
+++ b/method_cache.gemspec
@@ -1,0 +1,24 @@
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+Gem::Specification.new do |gem|
+  gem.name          = "method_cache"
+  gem.version       = "0.8.2.2"
+  gem.authors       = ["Justin Balthrop"]
+  gem.email         = ["git@justinbalthrop.com"]
+  gem.description   = %q{Simple memcache-based memoization library for Ruby}
+  gem.summary       = gem.description
+  gem.homepage      = "https://github.com/IFTTT/method_cache"
+  gem.license       = 'MIT'
+
+  gem.add_development_dependency 'shoulda'
+  gem.add_development_dependency 'mocha'
+  gem.add_development_dependency 'rake'
+  gem.add_development_dependency 'dalli'
+  gem.add_development_dependency 'activesupport', '~> 2.3.9'
+
+  gem.files         = `git ls-files`.split($/)
+  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+  gem.require_paths = ["lib"]
+end


### PR DESCRIPTION
After changing error trapping, we are still getting the exceptions for
`ValueOverMaxSize`.

See the Slack thread to understand how confusing this is. Its not
clear why its happening. Because we're looking to fold this gem into
IFE, a minimal approach is being tried.

In this case, its a bare `rescue`. If we don't get errors, yay! - we
can fold in the gem. If we do, we know something more deeply wrong is
going on.

https://app.shortcut.com/ifttt/story/106335/

https://ifttt.slack.com/archives/C03PT8NFTC4/p1686168900463709
